### PR TITLE
Add Ranometro web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-empty project
+# Ranómetro
+
+Aplicación web sencilla para conocer tu nivel de "ranidad". Abre `index.html` en tu navegador y presiona el botón para generar un resultado aleatorio.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ranómetro</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <main>
+        <h1>Ranómetro</h1>
+        <p>Descubre tu nivel de "ranidad" con un simple clic.</p>
+        <div id="resultado" class="resultado">Presiona el botón para comenzar</div>
+        <button id="generar">¿Cuán rana eres hoy?</button>
+    </main>
+    <audio id="croar" src="assets/frog.mp3" preload="auto"></audio>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,31 @@
+const boton = document.getElementById('generar');
+const resultadoEl = document.getElementById('resultado');
+const audio = document.getElementById('croar');
+
+const consejos = [
+    'Nunca dejes de saltar hacia tus metas.',
+    'Un poco de sol es todo lo que necesitas para brillar.',
+    'Mantén la calma y sigue croando.',
+    'La paciencia es la clave para atrapar esa mosca esquiva.'
+];
+
+function generarMensaje(numero) {
+    if (numero < 25) return 'Eres más humano que rana.';
+    if (numero < 50) return 'Tienes un toque de rana en ti.';
+    if (numero < 75) return '¡La rana que llevas dentro está asomando!';
+    return '¡Eres una auténtica rana!';
+}
+
+function mostrarResultado() {
+    const numero = Math.floor(Math.random() * 101); // 0-100
+    const mensaje = generarMensaje(numero);
+    const consejo = consejos[Math.floor(Math.random() * consejos.length)];
+
+    resultadoEl.textContent = `${mensaje} Resultado: ${numero}/100. Consejo: ${consejo}`;
+    if (audio && audio.play) {
+        audio.currentTime = 0;
+        audio.play().catch(() => {/* ignore errors */});
+    }
+}
+
+boton.addEventListener('click', mostrarResultado);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,28 @@
+body {
+    background-color: #d2f5a3; /* verde claro */
+    font-family: Arial, Helvetica, sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+main {
+    text-align: center;
+}
+
+button {
+    padding: 10px 20px;
+    margin-top: 1rem;
+    font-size: 1rem;
+    cursor: pointer;
+    border: none;
+    border-radius: 8px;
+}
+
+.resultado {
+    margin-top: 1rem;
+    font-size: 1.2rem;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- create simple landing page for Ranómetro with centered layout
- add playful styling and instructions in README
- implement random frog score logic with optional croak audio

## Testing
- `npm test` *(fails: ENOENT for package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cd10274388322991b9bca0b53a656